### PR TITLE
Add NTrig attribute to albaEM instructions.

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 1.3.0-alpha
+current_version = 1.2.10-alpha
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 1.2.10-alpha
+current_version = 1.2.11-alpha
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -3,7 +3,7 @@ commit = True
 message = Bump version {current_version} to {new_version}
 tag = False
 tag_name = {new_version}
-current_version = 1.2.10-alpha
+current_version = 1.3.0-alpha
 parse = (?P<major>\d+)\.(?P<minor>\d+)\.(?P<patch>\d+)(\-(?P<release>[a-z]+))?
 serialize = 
 	{major}.{minor}.{patch}-{release}

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ See more details in the doc directory of the sources repository.
 __url__ = "https://github.com/srgblnch/skippy"
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-__version__ = '1.2.10-alpha'
+__version__ = '1.3.0-alpha'
 
 
 from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ See more details in the doc directory of the sources repository.
 __url__ = "https://github.com/srgblnch/skippy"
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-__version__ = '1.2.10-alpha'
+__version__ = '1.2.11-alpha'
 
 
 from setuptools import setup, find_packages

--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ See more details in the doc directory of the sources repository.
 __url__ = "https://github.com/srgblnch/skippy"
 # we use semantic versioning (http://semver.org/) and we update it using the
 # bumpversion script (https://github.com/peritus/bumpversion)
-__version__ = '1.3.0-alpha'
+__version__ = '1.2.10-alpha'
 
 
 from setuptools import setup, find_packages

--- a/skippy/instructionSet.py
+++ b/skippy/instructionSet.py
@@ -71,7 +71,7 @@ def splitIDN(idn):
 
 def _getFilePath(filename):
     path = os.path.dirname(__file__)
-    full_path = path + '/' + filename
+    full_path = os.path.join(path, filename)
     return full_path
 
 

--- a/skippy/instructions/albaEm/albaEm.py
+++ b/skippy/instructions/albaEm/albaEm.py
@@ -132,6 +132,13 @@ Attribute('AcqTime',
            'writeCmd': lambda value: "ACQU:TIME %s" % (value),
            })
 
+Attribute('NTrig',
+          {'type': PyTango.CmdArgType.DevString,
+           'dim': [0],
+           'readCmd': "ACQU:NTRIggers?",
+           'writeCmd': lambda value: "ACQU:NTRIggers %s" % (value),
+           })
+
 # Channels ---
 Attribute('InstantCurrent',
           {'type': PyTango.CmdArgType.DevDouble,

--- a/skippy/version.py
+++ b/skippy/version.py
@@ -21,7 +21,7 @@ __email__ = "sblanch@cells.es"
 __copyright__ = "Copyright 2015, CELLS / ALBA Synchrotron"
 __license__ = "GPLv3+"
 
-__version__ = '1.3.0-alpha'
+__version__ = '1.2.10-alpha'
 
 
 def VERSION():

--- a/skippy/version.py
+++ b/skippy/version.py
@@ -21,7 +21,7 @@ __email__ = "sblanch@cells.es"
 __copyright__ = "Copyright 2015, CELLS / ALBA Synchrotron"
 __license__ = "GPLv3+"
 
-__version__ = '1.2.10-alpha'
+__version__ = '1.3.0-alpha'
 
 
 def VERSION():

--- a/skippy/version.py
+++ b/skippy/version.py
@@ -21,7 +21,7 @@ __email__ = "sblanch@cells.es"
 __copyright__ = "Copyright 2015, CELLS / ALBA Synchrotron"
 __license__ = "GPLv3+"
 
-__version__ = '1.2.10-alpha'
+__version__ = '1.2.11-alpha'
 
 
 def VERSION():

--- a/tester/instrIdn.py
+++ b/tester/instrIdn.py
@@ -24,7 +24,7 @@ __license__ = "GPLv3+"
 __status__ = "Production"
 
 import scpi
-__version__ = '1.3.0-alpha'
+__version__ = '1.2.10-alpha'
 
 
 class InstrumentIdentification(object):

--- a/tester/instrIdn.py
+++ b/tester/instrIdn.py
@@ -24,7 +24,7 @@ __license__ = "GPLv3+"
 __status__ = "Production"
 
 import scpi
-__version__ = '1.2.10-alpha'
+__version__ = '1.3.0-alpha'
 
 
 class InstrumentIdentification(object):

--- a/tester/instrIdn.py
+++ b/tester/instrIdn.py
@@ -24,7 +24,7 @@ __license__ = "GPLv3+"
 __status__ = "Production"
 
 import scpi
-__version__ = '1.2.10-alpha'
+__version__ = '1.2.11-alpha'
 
 
 class InstrumentIdentification(object):


### PR DESCRIPTION
This commit adds a new attribute to the AlbaEM instructions. This
attribute is needed to configure the number of triggers to receive
during an acquisition.

It also changes the way of building the path inside of the
instructionSet.py, in order to make it more platform independent.