### PR TITLE
Add Norhof pump controller

### DIFF
--- a/skippy/instructionSet.py
+++ b/skippy/instructionSet.py
@@ -44,6 +44,7 @@ def identifier(idn, deviceObj):
             'arroyo': arroyo,
             'albasynchrotron': albasynchrotron,
             'keithley instruments inc.': keithley,
+            'norhof': norhof,
             'fakeinstruments. inc': fakeinstrument,
             }[company](model)
     builder = Builder(deviceObj)
@@ -125,6 +126,10 @@ def keithley(model):
         return _getFilePath("instructions/sourcemeter/keithley26XX.py")
     raise EnvironmentError("Keithley %s model not supported" % (model))
 
+def norhof(model):
+    if model == '900':
+        return _getFilePath('instructions/pumpController/norhof900.py')
+    raise EnvironmentError("Norhof %s model not supported" % (model))
 
 def fakeinstrument(model):
     if model == 'tester':

--- a/skippy/instructions/pumpController/__init__.py
+++ b/skippy/instructions/pumpController/__init__.py
@@ -1,0 +1,23 @@
+# -*- coding: utf-8 -*-
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 3
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+__author__ = "Sergi Blanch-Torné"
+__email__ = "sblanch@cells.es"
+__copyright__ = "Copyright 2016, CELLS / ALBA Synchrotron"
+__license__ = "GPLv3+"

--- a/skippy/instructions/pumpController/norhof900.py
+++ b/skippy/instructions/pumpController/norhof900.py
@@ -1,0 +1,73 @@
+# ##### BEGIN GPL LICENSE BLOCK #####
+#
+#  This program is free software; you can redistribute it and/or
+#  modify it under the terms of the GNU General Public License
+#  as published by the Free Software Foundation; either version 3
+#  of the License, or (at your option) any later version.
+#
+#  This program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with this program; if not, write to the Free Software Foundation,
+#  Inc., 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301, USA.
+#
+# ##### END GPL LICENSE BLOCK #####
+
+__author__ = "Jordi Andreu Segura"
+__maintainer__ = "Jordi Andreu Segura"
+__email__ = "jandreu@cells.es"
+__copyright__ = "Copyright 2015, CELLS / ALBA Synchrotron"
+__license__ = "GPLv3+"
+__status__ = "Production"
+
+
+import PyTango
+
+Attribute('SCPIname',
+          {'type': PyTango.CmdArgType.DevString,
+           'dim': [0],
+           'readCmd': ":SYS:NAME?",
+           })
+
+Attribute('SerialNumber',
+          {'type': PyTango.CmdArgType.DevString,
+           'dim': [0],
+           'readCmd': ":SYS:SN?",
+           })
+
+Attribute('PumpStatus',
+          {'type': PyTango.CmdArgType.DevString,
+           'dim': [0],
+           'readCmd': ":SYS:STATUS?",
+           })
+
+Attribute('Temp',
+          {'type': PyTango.CmdArgType.DevString,
+           'dim': [0],
+           'readCmd': ":MEAS:TEMP?",
+           'writeCmd': lambda value: ":TEMP %s" % (value),
+           })
+
+Attribute('Flow',
+          {'type': PyTango.CmdArgType.DevString,
+           'dim': [0],
+           'readCmd': ":MEAS:FLOW?",
+           'writeCmd': lambda value: ":FLOW %s" % (value),
+           })
+
+Attribute('Mode',
+          {'type': PyTango.CmdArgType.DevString,
+           'dim': [0],
+           'readCmd': ":PUMP:MODE?",
+           'writeCmd': lambda value: ":PUMP:MODE %s" % (value),
+           })
+
+Attribute('Operation',
+          {'type': PyTango.CmdArgType.DevString,
+           'dim': [0],
+           'readCmd': ":PUMP:CONTROL?",
+           'writeCmd': lambda value: ":PUMP:CONTROL %s" % (value),
+           })


### PR DESCRIPTION
Add new instrument pumpController from Norhof.
The device communicates with an in-house SCPI server
which communicates to the hardware via serial.